### PR TITLE
Add safer update for URLs

### DIFF
--- a/Egineering.UrlShortener.Services/Exceptions/ConflictException.cs
+++ b/Egineering.UrlShortener.Services/Exceptions/ConflictException.cs
@@ -1,0 +1,7 @@
+﻿namespace Egineering.UrlShortener.Services.Exceptions;
+
+[ExcludeFromCodeCoverage]
+public class ConflictException : Exception
+{
+    public ConflictException(string vanity) : base($"The entry with vanity '{vanity}' already exists") { }
+}

--- a/Egineering.UrlShortener.Services/Interfaces/IAzureTableStorageService.cs
+++ b/Egineering.UrlShortener.Services/Interfaces/IAzureTableStorageService.cs
@@ -4,5 +4,6 @@ public interface IAzureTableStorageService
 {
     Task<string> GetUrlFromVanityAsync(string vanity);
     IEnumerable<ShortenedUrl> GetAllShortenedUrls();
-    Task SaveUrl(UrlRequest urlRequest);
+    Task AddUrl(UrlRequest urlRequest);
+    Task ReplaceUrl(UrlRequest urlRequest);
 }

--- a/Egineering.UrlShortener/Program.cs
+++ b/Egineering.UrlShortener/Program.cs
@@ -59,7 +59,7 @@ app.MapPost("/api/urls", async (UrlRequest urlRequest, IAzureTableStorageService
     {
         ValidateAuthHeader(httpContext.Request);
 
-        await service.SaveUrl(urlRequest);
+        await service.AddUrl(urlRequest);
 
         httpContext.Response.StatusCode = 204;
     }
@@ -71,6 +71,38 @@ app.MapPost("/api/urls", async (UrlRequest urlRequest, IAzureTableStorageService
     {
         httpContext.Response.StatusCode = 401;
         await httpContext.Response.WriteAsJsonAsync(new { message = unauthorizedException.Message });
+    }
+    catch (ConflictException conflictException)
+    {
+        httpContext.Response.StatusCode = 409;
+        await httpContext.Response.WriteAsJsonAsync(new { message = conflictException.Message });
+    }
+});
+
+app.MapPut("/api/urls", async (UrlRequest urlRequest, IAzureTableStorageService service,
+    HttpContext httpContext) =>
+{
+    try
+    {
+        ValidateAuthHeader(httpContext.Request);
+
+        await service.ReplaceUrl(urlRequest);
+
+        httpContext.Response.StatusCode = 204;
+    }
+    catch (RequestFailedException requestFailedException)
+    {
+        await HandleRequestFailedException(httpContext.Response, requestFailedException);
+    }
+    catch (UnauthorizedException unauthorizedException)
+    {
+        httpContext.Response.StatusCode = 401;
+        await httpContext.Response.WriteAsJsonAsync(new { message = unauthorizedException.Message });
+    }
+    catch (UrlEntityNotFoundException urlEntityNotFoundException)
+    {
+        httpContext.Response.StatusCode = 404;
+        await httpContext.Response.WriteAsJsonAsync(new { message = urlEntityNotFoundException.Message });
     }
 });
 


### PR DESCRIPTION
Split the Save method into Add and Replace methods.

If the user tries to `POST` a URL that already exists, they will get a `409 Conflict` response. If they want to go ahead and replace the URL anyway, they can issue a `PUT` request to the same endpoint. This will return a `404 Not Found` response if the user tries to update a URL that does not exist.

Since the choice of HTTP verb matters now, replacing an existing URL needs to be a deliberate action. This should help prevent someone from accidentally overwriting something.

At first, my opinion was that URLs should never be overwritten, but I can see some reasons why this might need to happen, so I think this is a happy medium for now. I think for the future, it might be nice to add some tighter controls for this.