### PR TITLE
Generate random url if user does not provide a vanity url

### DIFF
--- a/Egineering.UrlShortener.Services/AzureTableStorageService.cs
+++ b/Egineering.UrlShortener.Services/AzureTableStorageService.cs
@@ -17,13 +17,8 @@ public class AzureTableStorageService : IAzureTableStorageService
 
     public async Task<string> GetUrlFromVanityAsync(string vanity)
     {
-        var urlEntity = await GetUrlEntityByVanity(vanity);
-
-        if (urlEntity == null)
-        {
-            throw new UrlEntityNotFoundException(vanity);
-        }
-
+        var urlEntity = await GetUrlEntityByVanity(vanity)
+            ?? throw new UrlEntityNotFoundException(vanity);
         var urlEntityName = urlEntity.GetString(Constants.Name);
         var urlEntityUrl = urlEntity.GetString(Constants.Url);
         var currentUrlVisits = urlEntity.GetInt32(Constants.Visits);
@@ -113,20 +108,16 @@ public class AzureTableStorageService : IAzureTableStorageService
 
     public async Task ReplaceUrl(UrlRequest urlRequest)
     {
-        var urlEntity = await GetUrlEntityByVanity(urlRequest.Vanity);
-
-        if (urlEntity == null)
-        {
-            throw new UrlEntityNotFoundException(urlRequest.Vanity);
-        }
+        var urlEntity = await GetUrlEntityByVanity(urlRequest.Vanity)
+            ?? throw new UrlEntityNotFoundException(urlRequest.Vanity);
 
         var entity = new TableEntity(Constants.UrlPartitionKey, urlRequest.Vanity)
-            {
-                { Constants.Name, urlRequest.Name },
-                { Constants.Url, urlRequest.Url },
-                { Constants.Visits, urlEntity.GetInt32(Constants.Visits) },
-                { Constants.IsPublic, urlRequest.IsPublic },
-            };
+        {
+            { Constants.Name, urlRequest.Name },
+            { Constants.Url, urlRequest.Url },
+            { Constants.Visits, urlEntity.GetInt32(Constants.Visits) },
+            { Constants.IsPublic, urlRequest.IsPublic },
+        };
 
         await _tableClient.UpdateEntityAsync(entity, ETag.All);
     }

--- a/Egineering.UrlShortener.Services/Interfaces/IAzureTableStorageService.cs
+++ b/Egineering.UrlShortener.Services/Interfaces/IAzureTableStorageService.cs
@@ -4,6 +4,6 @@ public interface IAzureTableStorageService
 {
     Task<string> GetUrlFromVanityAsync(string vanity);
     IEnumerable<ShortenedUrl> GetAllPublicUrls();
-    Task AddUrl(UrlRequest urlRequest);
+    Task<string> AddUrl(UrlRequest urlRequest);
     Task ReplaceUrl(UrlRequest urlRequest);
 }

--- a/Egineering.UrlShortener/Program.cs
+++ b/Egineering.UrlShortener/Program.cs
@@ -61,9 +61,11 @@ app.MapPost("/api/urls", async (UrlRequest urlRequest, IAzureTableStorageService
     {
         ValidateAuthHeader(httpContext.Request);
 
-        await service.AddUrl(urlRequest);
+        var vanity = await service.AddUrl(urlRequest);
 
-        httpContext.Response.StatusCode = 204;
+        httpContext.Response.StatusCode = 201;
+        var shortenedUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}/{vanity}";
+        await httpContext.Response.WriteAsJsonAsync(new { shortenedUrl });
     }
     catch (RequestFailedException requestFailedException)
     {


### PR DESCRIPTION
If the user wants to use the service just to shorten a URL and does not care what the vanity is, they can leave the vanity field blank and we will generate a random short string. The POST request to /urls will now return the shortened URL instead of a blank 204 response.

[screen-recorder-wed-oct-11-2023-19-12-05.webm](https://github.com/egineering-llc/urlshortener/assets/19156328/46c3c761-c1a0-4f2f-99f1-6de5741ea654)
